### PR TITLE
Fixed syntax error in schema and Init test for beds apps

### DIFF
--- a/src/beds/schema.py
+++ b/src/beds/schema.py
@@ -72,7 +72,7 @@ class CreateBed(graphene.Mutation):
 class Query(graphene.ObjectType):
     beds = graphene.List(BedType)
     # beds_by_garden = graphene.Field(Bed, gardenId=Int(required=False))
-    
+
     # def resolve_beds_by_garden(self, info, gardenId):
     #     try:
     #         user = info.context.user
@@ -95,8 +95,8 @@ class Query(graphene.ObjectType):
 
     def resolve_beds(self, info):
         user = info.context.user
-        if not ( user.is_superuser || user.is_staff ):
-            raise Exception("You must be a superuser to view all beds")
+        if not ( user.is_superuser | user.is_staff ):
+            raise Exception("You must be a superuser or staff to view all beds")
         return Bed.objects.all()
 
 

--- a/src/beds/tests.py
+++ b/src/beds/tests.py
@@ -1,3 +1,22 @@
-from django.test import TestCase
+import json
+from graphene_django.utils.testing import GraphQLTestCase
 
-# Create your tests here.
+
+class TestGraphQLQueries(GraphQLTestCase):
+    """
+    Test that querying all beds isn't possible as anonymous user
+    """
+
+    def test_beds_query(self):
+        response = self.query(
+            """
+            query {
+                beds {
+                    id
+                    bedName
+                }
+            }
+            """
+        )
+        error_message = json.loads(response.content).get('errors')[0].get('message')
+        assert 'You must be a superuser or staff' in error_message

--- a/src/plants/schema.py
+++ b/src/plants/schema.py
@@ -61,8 +61,8 @@ class CreateSection(graphene.Mutation):
             end_date=end_date,
             is_active=is_active,
             start_date=start_date,
-            square_footage=square_footage
-            square_footage_sfg=square_footage_sfg
+            square_footage=square_footage,
+            square_footage_sfg=square_footage_sfg,
             section=section
         )
 


### PR DESCRIPTION
## Fixed Syntax Error & Init Test  

### Changes proposed in this pull request:

* Fixed Syntax Error in Beds Schema: change `||` to `|`
* Fixed Syntax Error in Plants Schema: missing `,`
* Init Test for Beds Apps

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Additional notes

* Refer to this issue #15 
* I do recommend to use https://factoryboy.readthedocs.io/en/latest/ to ease the test development in the future
