### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,10 @@ graphql-relay==2.0.1
 isort==5.4.2
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-pkg-resources==0.0.0
 promise==2.3
 psycopg2-binary==2.8.5
 pylint==2.6.0
-pytest=6.1.1
+pytest==6.1.1
 pytz==2020.1
 Rx==1.6.1
 singledispatch==3.4.0.3


### PR DESCRIPTION
## Related to:
Resolves: #34

## Description:
remove pkg-resources  requirement https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command
and fix pytest requirement

